### PR TITLE
Make install script more complete and verbose

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,16 @@ HERE=$(pwd)
 
 . ./config.env
 
+
+echo "=> Installing debian packages"
+sudo apt-get install python3-pip nginx redis-server mplayer
+
+
+echo "=> Installing pip packages"
+pip3 install --user --upgrade cherrypy youtube-dl redis pyserial
+
+
+echo "=> Creating systemd services"
 mkdir -p $HOME/.config/systemd/user
 
 for x in webserver.service downloader.service player.service button.service
@@ -12,11 +22,15 @@ do
 	cat $HERE/$x | sed "s|DIR|$HERE|g" >$HOME/.config/systemd/user/$x
 done
 
+
+echo "=> Setting up nginx web server"
 cat $HERE/nginx-site | sed "s|DIR|$MZ_LOCATION|" | sudo tee /etc/nginx/sites-available/musicazoo > /dev/null
+sudo ln -sf /etc/nginx/sites-available/musicazoo /etc/nginx/sites-enabled/musicazoo
 
-pip3 install --user --upgrade cherrypy youtube-dl redis pyserial
 
-sudo systemctl start redis-server
+echo "=> Starting systemd services"
+sudo systemctl restart redis-server nginx
+sudo loginctl enable-linger $USER
 systemctl daemon-reload --user
 systemctl enable --user webserver downloader player
 systemctl start --user webserver downloader player

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ HERE=$(pwd)
 
 
 echo "=> Installing debian packages"
+sudo apt-get update
 sudo apt-get install python3-pip nginx redis-server mplayer
 
 
@@ -33,9 +34,9 @@ sudo systemctl restart redis-server nginx
 sudo loginctl enable-linger $USER
 systemctl daemon-reload --user
 systemctl enable --user webserver downloader player
-systemctl start --user webserver downloader player
+systemctl restart --user webserver downloader player
 if [ "$MZ_BUTTON" == "true" ]
 then
 	systemctl enable --user button
-	systemctl start --user button
+	systemctl restart --user button
 fi


### PR DESCRIPTION
Ideally it should take us from a fresh Debian install to a fully-working musicazoo.

The `loginctl enable-linger` prevents the user services from dying when the user is logged out; alternatively it might be reasonable to have global services and global pip package installs since a lot of this stuff involves system-wide configuration anyway.