### PR TITLE
Prevent running the installer as root

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+[[ $USER != root ]] || (echo "Must not be root"; exit 1)
+
 cd $(dirname $0)
 HERE=$(pwd)
 


### PR DESCRIPTION
The install script doesn't expect to be run as root, and if someone accidentally runs it as root, that'll cause issues if they re-run it as the non-root musicazoo user since there'll be duplicate systemd services for root and for the non-root user. This is a quick safety check to prevent mistakes.